### PR TITLE
fix: store sessionUrl in payment record for retry support

### DIFF
--- a/backend-nest/prisma/migrations/20260324122057_add_session_url_to_payment/migration.sql
+++ b/backend-nest/prisma/migrations/20260324122057_add_session_url_to_payment/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "payments" ADD COLUMN     "sessionUrl" TEXT;

--- a/backend-nest/prisma/schema.prisma
+++ b/backend-nest/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Payment {
   currency        String        @default("UAH")
   status          PaymentStatus @default(PENDING)
   stripeSessionId String?
+  sessionUrl      String?
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
 

--- a/backend-nest/src/payments/payments.service.ts
+++ b/backend-nest/src/payments/payments.service.ts
@@ -151,7 +151,7 @@ export class PaymentsService {
 
 				await this.prisma.payment.update({
 					where: { id: payment.id },
-					data: { stripeSessionId: session.id },
+					data: { stripeSessionId: session.id, sessionUrl: session.url },
 				});
 			} catch (err: unknown) {
 				this.logger.error(


### PR DESCRIPTION
  - Add sessionUrl column to Payment model (Prisma migration)
  - Save Stripe session URL when creating payment
  - Allows frontend to redirect to existing Stripe session on retry