### PR TITLE
fix: compact date format in admin tables (dd.MM.yyyy)

### DIFF
--- a/frontend/src/pages/Admin/AdminBookings.tsx
+++ b/frontend/src/pages/Admin/AdminBookings.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../store/slices/bookingsSlice';
 import { fetchAllPayments } from '../../store/slices/paymentsSlice';
 import type { Booking, Payment, User } from '../../types';
-import { formatDate } from '../../utils/dateCalc';
+import { formatDateCompact } from '../../utils/dateCalc';
 import { localized } from '../../utils/translations';
 import AdminBookingCard from './AdminBookingCard';
 import AdminTable from './AdminTable';
@@ -117,12 +117,14 @@ const AdminBookings = () => {
 		{
 			key: 'checkInDate',
 			label: t('admin.checkIn'),
-			render: (r: Record<string, unknown>) => formatDate(r.checkInDate as string | undefined),
+			render: (r: Record<string, unknown>) =>
+				formatDateCompact(r.checkInDate as string | undefined),
 		},
 		{
 			key: 'checkOutDate',
 			label: t('admin.checkOut'),
-			render: (r: Record<string, unknown>) => formatDate(r.checkOutDate as string | undefined),
+			render: (r: Record<string, unknown>) =>
+				formatDateCompact(r.checkOutDate as string | undefined),
 		},
 		{
 			key: 'totalPrice',

--- a/frontend/src/styles/components/admin/_admin.scss
+++ b/frontend/src/styles/components/admin/_admin.scss
@@ -27,7 +27,6 @@
   td {
     padding: 1.1rem 1rem;
     text-align: left;
-    white-space: nowrap;
     border-bottom: 1px solid var(--table-border);
   }
 

--- a/frontend/src/utils/dateCalc.ts
+++ b/frontend/src/utils/dateCalc.ts
@@ -22,3 +22,13 @@ export const formatDate = (date: string | Date | null | undefined): string => {
 		year: 'numeric',
 	});
 };
+
+/** Compact date for tables: "10.07.2026" */
+export const formatDateCompact = (date: string | Date | null | undefined): string => {
+	if (!date) return '—';
+	const d = typeof date === 'string' ? new Date(date) : date;
+	if (Number.isNaN(d.getTime())) return '—';
+	const dd = String(d.getDate()).padStart(2, '0');
+	const mm = String(d.getMonth() + 1).padStart(2, '0');
+	return `${dd}.${mm}.${d.getFullYear()}`;
+};


### PR DESCRIPTION
  - Add formatDateCompact util for tables
  - Use compact dates in AdminBookings to prevent horizontal scroll
  - Remove white-space: nowrap from table cells